### PR TITLE
djangobuilder.py doesn't follow Django's project name restrictions.

### DIFF
--- a/djangobuilder.py
+++ b/djangobuilder.py
@@ -11,6 +11,7 @@
 import commands
 import os
 import random
+import re
 import shutil
 import string
 import sys
@@ -69,6 +70,17 @@ parser.add_argument('-q', '--quiet', action='store_true', default=False,
 
 
 arguments = parser.parse_args()
+
+def check_projectname():
+    if not re.search(r'^[_a-zA-Z]\w*$', PROJECT_NAME):
+        message = 'Error: \'%s\' is not a valid project name. Please ' %  PROJECT_NAME
+        if not re.search(r'^[_a-zA-Z]', PROJECT_NAME):
+            message += ('make sure the name begins '
+                       'with a letter or underscore.')
+        else:
+            message += 'use only numbers, letters and underscores.'
+
+    sys.exit(message)
 
 def copy_files(folder_path, file_types, pathify):
     """Copies the contents of django_files and server_scripts, and
@@ -141,6 +153,9 @@ replacement_values = {
 
 # Doing it this way so DPB can add 'extra_settings' on the fly.
 needed_dirs = ['static', 'apache', '%(PROJECT_NAME)s', '%(APP_NAME)s']
+
+# Make sure PROJECT_NAME follows Django's restrictions
+check_projectname()
 
 if not arguments.quiet:
     print "Creating directories..."


### PR DESCRIPTION
This adds a check_projectname() function to make sure PROJECT_NAME follows Django's project name restrictions.  Simple regex to check and it will sys.exit() if PROJECT_NAME is not valid.

Currently, this is allowed:

```
$ python djangobuilder.py --path test-test
```

This commit will now enforce this:

```
$ python djangobuilder.py --path test-test
Error: 'test-test' is not a valid project name. Please use only numbers, letters and underscores.
```

and

```
$ python djangobuilder.py --path 123test
Error: '123test' is not a valid project name. Please make sure the name begins with a letter or underscore.
```
