### PR TITLE
Removed deprecated --no-site-packages in djangobuilder.py

### DIFF
--- a/djangobuilder.py
+++ b/djangobuilder.py
@@ -236,7 +236,7 @@ if not arguments.quiet:
     print "Making virtualenv..."
 
 cmd  = 'bash -c "source %s &&' % VIRTUALENV_WRAPPER_PATH
-cmd += ' mkvirtualenv %s --no-site-packages"' % PROJECT_NAME
+cmd += ' mkvirtualenv %s"' % PROJECT_NAME
 
 output = sh(cmd)
 


### PR DESCRIPTION
Fixed mkvirtualenv warning which would display

<pre>
The --no-site-packages flag is deprecated; it is now the default behavior.
</pre>
