### PR TITLE
Created install_dependencies.sh script to automate the process for new people

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ using all Foundation 3 defaults for the front-end.
 `virtualenv` and `virtualenvwrapper` are required. `git` is
 recommended. Django is awesome.
 
+### Installing Dependencies
+
+If you're on a Mac (only been tested with OSX Lion so far) and are missing
+some dependencies like `pip`, `django`, `virtualenv`, or `virtualenvwrapper`
+then `cd` into the repo and run
+
+    bash install_dependencies.sh
 
 ### Server Usage
 

--- a/django-files/settings.py-needed
+++ b/django-files/settings.py-needed
@@ -103,6 +103,10 @@ MIDDLEWARE_CLASSES = (
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
+LOGIN_URL = '/login/'
+
+LOGOUT_URL = '/logout/'
+
 ROOT_URLCONF = '%(PROJECT_NAME)s.urls'
 
 WSGI_APPLICATION = '%(PROJECT_NAME)s.wsgi.application'

--- a/django-files/settings.py-needed
+++ b/django-files/settings.py-needed
@@ -103,6 +103,10 @@ MIDDLEWARE_CLASSES = (
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
+from django.core.urlresolvers import reverse_lazy
+
+LOGIN_REDIRECT_URL = reverse_lazy('index')
+
 LOGIN_URL = '/login/'
 
 LOGOUT_URL = '/logout/'

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -6,21 +6,38 @@
 # Tested on a Mac OSX 10.7 Lion
 
 # Installing pip, django, virtualenv, virtualenvwrapper
-echo "Installing pip..."
-sudo easy_install pip
-echo "Installing django..."
-sudo pip install django
-echo "Installing virtualenv..."
-sudo pip install virtualenv
-echo "Installing virtualenvwrapper..."
-sudo pip install virtualenvwrapper
+if [ -z `which pip` ]
+    then
+        echo "Installing pip..."
+        sudo easy_install pip
+fi
+
+if [ -z `which django-admin.py` ]
+    then
+        echo "Installing django..."
+        sudo pip install django
+fi
+
+if [ -z `which virtualenv` ]
+    then
+        echo "Installing virtualenv..."
+        sudo pip install virtualenv
+fi
+
+if [ -z `which virtualenvwrapper.sh` ]
+    then
+        echo "Installing virtualenvwrapper..."
+        sudo pip install virtualenvwrapper
+fi
 
 # Adds lines to the shell startup file so that virtualenvwrapper can work
 # http://virtualenvwrapper.readthedocs.org/en/latest/install.html#shell-startup-file
-echo "Adding virtualenvwrapper variables to ~/.bash_profile"
-echo source `which virtualenvwrapper.sh` >> ~/.bash_profile
-echo "export WORKON_HOME=$HOME/.virtualenvs" >> ~/.bash_profile
-source ~/.bash_profile
+if [ ! -d "$WORKON_HOME" ]
+    then
+        echo "Adding virtualenvwrapper variables to ~/.bash_profile"
+        echo source `which virtualenvwrapper.sh` >> ~/.bash_profile
+        source ~/.bash_profile
+fi
 
 # Fixes problem that occurs on OSX 10.7 Lion when making a new virtualenv,
 # it goes looking for disutils but crashes if it can't find one
@@ -33,3 +50,5 @@ if [ -z `which git` ]
         echo "Detected git has not been installed"
         echo "INSTALL git here http://git-scm.com/downloads"
 fi
+
+echo "All dependencies installed!"

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Kevin Xu / imkevinxu
+# 2012.08.23
+
+# Basic script to install all the dependencies for Django Project Builder
+# Tested on a Mac OSX 10.7 Lion
+
+# Installing pip, django, virtualenv, virtualenvwrapper
+echo "Installing pip..."
+sudo easy_install pip
+echo "Installing django..."
+sudo pip install django
+echo "Installing virtualenv..."
+sudo pip install virtualenv
+echo "Installing virtualenvwrapper..."
+sudo pip install virtualenvwrapper
+
+# Adds lines to the shell startup file so that virtualenvwrapper can work
+# http://virtualenvwrapper.readthedocs.org/en/latest/install.html#shell-startup-file
+echo "Adding virtualenvwrapper variables to ~/.bash_profile"
+echo source `which virtualenvwrapper.sh` >> ~/.bash_profile
+echo "export WORKON_HOME=$HOME/.virtualenvs" >> ~/.bash_profile
+source ~/.bash_profile
+
+# Fixes problem that occurs on OSX 10.7 Lion when making a new virtualenv,
+# it goes looking for disutils but crashes if it can't find one
+# http://stackoverflow.com/questions/3129852/python-cant-locate-distutils-path-on-mac-osx
+sudo touch /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/__init__.py
+
+# Detects if the user has git installed and prompts them to install it if not
+if [ -z `which git` ]
+    then
+        echo "Detected git has not been installed"
+        echo "INSTALL git here http://git-scm.com/downloads"
+fi


### PR DESCRIPTION
I've been getting a bunch of my friends to start using django-projectbuilder but the most annoying/time-consuming part has been installing all the dependencies (`pip`, `django`, `virtualenv`, `virtualenvwrapper`).

So I created this script to automate the process and so far have tested it with Mac OSX 10.7 Lion. This is also my first bash script ever so it probably needs some more error-checking, feel free to discuss.
